### PR TITLE
Modified RHEL 7 update task and add new RHEL 7 task to remove a word from grub

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -50,7 +50,7 @@
 - name: Remove arguments from Grub default config for RedHat >= 7
   lineinfile:
     dest: "{{ grub_cmdline_default }}"
-    regexp: '^(.*){{ item }}(.*)$'
+    regexp: '^(GRUB_CMDLINE_LINUX.*){{ item }}(.*)$'
     line: '\1\2'
     backrefs: yes
   with_items: "{{ grub_cmdline_remove_args }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -42,6 +42,21 @@
     regexp: '^GRUB_CMDLINE_LINUX="'
   when: >
     ansible_os_family == "RedHat" and
-    ansible_distribution_major_version | int >= 7
+    ansible_distribution_major_version | int >= 7 and
+    grub_cmdline_add_args | length > 0
+  notify:
+    - Update Grub2 config file
+
+- name: Remove arguments from Grub default config for RedHat >= 7
+  lineinfile:
+    dest: "{{ grub_cmdline_default }}"
+    regexp: '^(.*){{ item }}(.*)$'
+    line: '\1\2'
+    backrefs: yes
+  with_items: "{{ grub_cmdline_remove_args }}"
+  when: >
+    ansible_os_family == "RedHat" and
+    ansible_distribution_major_version | int >= 7 and
+    grub_cmdline_remove_args | length > 0
   notify:
     - Update Grub2 config file


### PR DESCRIPTION
Modified the RHEL 7 update task to only execute when grub_cmdline_add_args has values.
Created a new RHEL 7 task to delete each word defined in grub_cmdline_remove_args. Prior to this change, by default grub_cmdline_add_args did nothing for RHEL 7 and the default task would remove all the arrangements from GRUB_CMDLINE_LINUX, leaving you with just GRUB_CMDLINE_LINUX="".